### PR TITLE
Flexdll: Bump NPM version

### DIFF
--- a/esy/package.json
+++ b/esy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexdll-prebuilt",
-  "version": "0.37.0001",
+  "version": "0.37.0002",
   "description": "Prebuilt flexdll/flexlink binaries",
   "main": "index.js",
   "esy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexdll",
-  "version": "0.37.0001",
+  "version": "0.37.0002",
   "description": "flexdll",
   "license": "MIT",
   "esy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexdll",
-  "version": "0.37.0002",
+  "version": "0.37.1002",
   "description": "flexdll",
   "license": "MIT",
   "esy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexdll",
-  "version": "0.37.1002",
+  "version": "0.37.0002",
   "description": "flexdll",
   "license": "MIT",
   "esy": {


### PR DESCRIPTION
The previous NPM released version didn't pick up all the latest fixes; this publishes a new version from `master`.