### PR TITLE
Use lower limit for script execution

### DIFF
--- a/reloc.ml
+++ b/reloc.ml
@@ -68,7 +68,8 @@ let read_file fn =
 let get_output ?(use_bash = false) ?(accept_error=false) cmd =
   let fn = Filename.temp_file "flexdll" "" in
   let cmd' = cmd ^ " > " ^ (Filename.quote fn) in
-    if String.length cmd' < 8161 && not use_bash then
+    (* Lower the limit for our shell command to 8191 (max command length) - 260 (max path length) = 7931 *)
+    if String.length cmd' < 7931 && not use_bash then
       begin
         if (Sys.command cmd' <> 0) && not accept_error
         then failwith ("Cannot run " ^ cmd);


### PR DESCRIPTION
__Issue:__ We're still hitting failures in our build after the switch to Azure CI:

```
2018-11-13T03:20:27.1568500Z error: build failed with exit code: 1
2018-11-13T03:20:27.1568797Z   build log:
2018-11-13T03:20:27.1568975Z     # esy-build-package: building: @opam/ppx_expect@opam:v0.11.0
2018-11-13T03:20:27.1569052Z 
2018-11-13T03:20:27.1569208Z     # esy-build-package: running: "bash" "-c" "patch -p1 < ppx_expect.v0.11.0.patch"
2018-11-13T03:20:27.1569293Z 
2018-11-13T03:20:27.1569433Z     patching file expect_payload/ppx_expect_payload.ml
2018-11-13T03:20:27.1569599Z     # esy-build-package: running: "jbuilder" "build" "-p" "ppx_expect" "-j" "4"
2018-11-13T03:20:27.1569678Z 
2018-11-13T03:20:27.1569823Z         ocamlopt .ppx/jbuild/b7f30f20ce9642a10df9c5dee7079add/ppx.exe (exit 2)
2018-11-13T03:20:27.1569902Z 
2018-11-13T03:20:27.1573869Z     (cd _build/default && C:\Users\VssAdministrator\.esy\3_\i\ocaml-4.6.7-f7371bd2\bin\ocamlopt.opt.exe -o .ppx/jbuild/b7f30f20ce9642a10df9c5dee7079add/ppx.exe -I 
...
2018-11-13T03:20:27.1577812Z 
2018-11-13T03:20:27.1577961Z     The command line is too long.
2018-11-13T03:20:27.1578032Z 
2018-11-13T03:20:27.1578125Z 
2018-11-13T03:20:27.1578220Z     ** Fatal error: Error during linking
```
[sample build](https://dev.azure.com/esy-dev/esy/_build/results?buildId=517&view=logs)

__Fix:__ We've tweaked this limit a number of times. It seems that the paths for Azure are slightly longer due to the `VssAdministrator` name. I suspect that the _working directory_ is included / counted against in the limit, so I'm using a revised limit of:
`8191` (Max command length ) - `260` (max path length), which is `7931`.  I hope that this lowered limit finally addresses issues for good! It does make the build pass now on Azure CI.